### PR TITLE
refactor(js): 使用 jgit 依赖的 commons codec  DigestUtils 替换 hutool-crypto DigestUtil 工具减少依赖

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,15 +56,9 @@
         </dependency>
         <dependency>
             <groupId>cn.hutool</groupId>
-            <artifactId>hutool-crypto</artifactId>
-            <version>${hutool.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>cn.hutool</groupId>
             <artifactId>hutool-system</artifactId>
             <version>${hutool.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/src/main/java/com/laker/postman/service/js/JsPolyfillInjector.java
+++ b/src/main/java/com/laker/postman/service/js/JsPolyfillInjector.java
@@ -1,7 +1,7 @@
 package com.laker.postman.service.js;
 
-import cn.hutool.crypto.digest.DigestUtil;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.proxy.ProxyExecutable;
 
@@ -44,7 +44,7 @@ public class JsPolyfillInjector {
     private static void injectMD5(Context context) {
         context.getBindings("js").putMember("MD5", (ProxyExecutable) args -> {
             String str = args[0].asString();
-            return DigestUtil.md5Hex(str);
+            return DigestUtils.md5Hex(str);
         });
     }
 
@@ -54,7 +54,7 @@ public class JsPolyfillInjector {
     private static void injectSHA256(Context context) {
         context.getBindings("js").putMember("SHA256", (ProxyExecutable) args -> {
             String str = args[0].asString();
-            return DigestUtil.sha256Hex(str);
+            return DigestUtils.sha256Hex(str);
         });
     }
 }


### PR DESCRIPTION
## 📝 PR 描述 | Description

- 将 MD5 和 SHA256 加密方法从 Hutool 工具类切换至 Apache Commons Codec

## 🔗 相关 Issue | Related Issue

无

## 🎯 改动类型 | Type of Change

- [ ] 🐛 Bug 修复 | Bug fix
- [ ] ✨ 新功能 | New feature
- [ ] 📝 文档更新 | Documentation update
- [x] 🎨 代码优化 | Code refactoring
- [ ] ⚡️ 性能优化 | Performance improvement
- [ ] 🔧 配置变更 | Configuration change
- [ ] 🧪 测试相关 | Test related
- [ ] 🔨 构建相关 | Build related
- [ ] 🌐 国际化 | Internationalization

## 📋 改动内容 | Changes Made

jgit 中依赖了 commons codec 的 DigestUtils，跟 hutool-crypto DigestUtil 有相同功能，可去掉

- 

## 🧪 测试 | Testing

- [x] 本地编译通过 | Local build passed
- [x] 功能测试通过 | Functional tests passed
- [x] 在以下环境测试 | Tested on:
  - [x] Windows
  - [ ] macOS
  - [ ] Linux

## 📸 截图 | Screenshots

<img width="1442" height="1002" alt="image" src="https://github.com/user-attachments/assets/45d5a4c2-3013-4838-a9fe-6a4a812bdbb9" />

## ✅ 检查清单 | Checklist

- [ ] 代码遵循项目编码规范 | Code follows the project's coding standards
- [ ] 已添加必要的注释 | Added necessary comments
- [ ] 文档已更新（如需要）| Documentation updated (if needed)
- [ ] 没有引入新的警告 | No new warnings introduced
- [x] 改动不影响现有功能 | Changes do not affect existing functionality
- [x] 已在本地完整测试 | Fully tested locally

## 💡 其他说明 | Additional Notes

无
---

感谢你的贡献！ | Thank you for your contribution! 🎉

