### PR TITLE
feat: supports switching SSE response ui within HTTP

### DIFF
--- a/src/main/java/com/laker/postman/panel/collections/right/request/sub/ResponsePanel.java
+++ b/src/main/java/com/laker/postman/panel/collections/right/request/sub/ResponsePanel.java
@@ -117,11 +117,16 @@ public class ResponsePanel extends JPanel {
                     I18nUtil.getMessage(MessageKeys.TAB_RESPONSE_HEADERS),
                     I18nUtil.getMessage(MessageKeys.TAB_TESTS),
                     I18nUtil.getMessage(MessageKeys.TAB_NETWORK_LOG),
-                    I18nUtil.getMessage(MessageKeys.TAB_TIMING)
+                    I18nUtil.getMessage(MessageKeys.TAB_TIMING),
+                    I18nUtil.getMessage(MessageKeys.MENU_FILE_LOG)
             };
             tabButtons = new JButton[tabNames.length];
             for (int i = 0; i < tabNames.length; i++) {
                 tabButtons[i] = new TabButton(tabNames[i], i);
+                // 默认情况下HTTP模式不显示日志tab
+                if (i == 5) {
+                    tabButtons[i].setVisible(false);
+                }
                 tabBar.add(tabButtons[i]);
             }
             JPanel statusBar = new JPanel(new FlowLayout(FlowLayout.RIGHT, 16, 4));
@@ -150,8 +155,9 @@ public class ResponsePanel extends JPanel {
             cardPanel.add(testsPanel, tabNames[2]);
             cardPanel.add(networkLogPanel, tabNames[3]);
             cardPanel.add(new JScrollPane(timelinePanel), tabNames[4]);
+            sseResponsePanel = new SSEResponsePanel();
+            cardPanel.add(sseResponsePanel, tabNames[5]);
             webSocketResponsePanel = null;
-            sseResponsePanel = null;
         }
         add(cardPanel, BorderLayout.CENTER);
 
@@ -420,10 +426,26 @@ public class ResponsePanel extends JPanel {
             timelinePanel.revalidate();
             timelinePanel.repaint();
             networkLogPanel.clearLog();
+            sseResponsePanel.clearMessages();
         }
 
         if (testsPane != null) {
             setTestResults(new ArrayList<>());
+        }
+    }
+
+    /**
+     * 切换Tab按钮，http或sse
+     */
+    public void switchTabButtonHttpOrSse(String type) {
+        if ("http".equals(type)) {
+            tabButtons[0].setVisible(true);
+            tabButtons[0].doClick();
+            tabButtons[5].setVisible(false);
+        } else {
+            tabButtons[0].setVisible(false);
+            tabButtons[5].setVisible(true);
+            tabButtons[5].doClick();
         }
     }
 

--- a/src/main/java/com/laker/postman/service/http/HttpSingleRequestExecutor.java
+++ b/src/main/java/com/laker/postman/service/http/HttpSingleRequestExecutor.java
@@ -2,6 +2,7 @@ package com.laker.postman.service.http;
 
 import com.laker.postman.model.HttpResponse;
 import com.laker.postman.model.PreparedRequest;
+import com.laker.postman.service.http.sse.SseResEventListener;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.WebSocketListener;
@@ -13,7 +14,11 @@ import okhttp3.sse.EventSourceListener;
 public class HttpSingleRequestExecutor {
 
     public static HttpResponse executeHttp(PreparedRequest req) throws Exception {
-        return HttpService.sendRequest(req);
+        return HttpService.sendRequest(req, null);
+    }
+
+    public static HttpResponse executeHttp(PreparedRequest req, SseResEventListener callback) throws Exception {
+        return HttpService.sendRequest(req, callback);
     }
 
     public static EventSource executeSSE(PreparedRequest req, EventSourceListener listener) {

--- a/src/main/java/com/laker/postman/service/http/RedirectHandler.java
+++ b/src/main/java/com/laker/postman/service/http/RedirectHandler.java
@@ -6,6 +6,7 @@ import com.laker.postman.model.HttpResponse;
 import com.laker.postman.model.PreparedRequest;
 import com.laker.postman.model.RedirectInfo;
 import com.laker.postman.panel.collections.right.RequestEditPanel;
+import com.laker.postman.service.http.sse.SseResEventListener;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,7 +24,7 @@ import java.util.Map;
 @UtilityClass
 public class RedirectHandler {
 
-    public static HttpResponse executeWithRedirects(PreparedRequest req, int maxRedirects) throws Exception {
+    public static HttpResponse executeWithRedirects(PreparedRequest req, int maxRedirects, SseResEventListener callback) throws Exception {
         // 创建工作副本
         PreparedRequest workingReq = req.shallowCopy();
         workingReq.logEvent = true; // 记录事件日志
@@ -32,7 +33,7 @@ public class RedirectHandler {
         int redirectCount = 0;
 
         while (redirectCount <= maxRedirects) {
-            HttpResponse resp = HttpSingleRequestExecutor.executeHttp(workingReq);
+            HttpResponse resp = HttpSingleRequestExecutor.executeHttp(workingReq, callback);
 
             // 更新原始请求对象的 OkHttp 相关字段
             req.okHttpHeaders = workingReq.okHttpHeaders;

--- a/src/main/java/com/laker/postman/service/http/sse/SseResEventListener.java
+++ b/src/main/java/com/laker/postman/service/http/sse/SseResEventListener.java
@@ -1,0 +1,8 @@
+package com.laker.postman.service.http.sse;
+
+import com.laker.postman.model.HttpResponse;
+import okhttp3.internal.sse.ServerSentEventReader;
+
+public interface SseResEventListener extends ServerSentEventReader.Callback {
+    void onOpen(HttpResponse response);
+}


### PR DESCRIPTION
## 📝 PR 描述 | Description

针对http类型，支持根据响应自动切换http和sse。另外为了兼容性，不改变原有sse类型的功能逻辑。

## 🔗 相关 Issue | Related Issue

<!-- 如果此 PR 解决了某个 Issue，请在此关联 | If this PR fixes an issue, please link it here -->
Fixes #76 

## 🎯 改动类型 | Type of Change

<!-- 请勾选适用的选项 | Please check the applicable options -->

- [ ] 🐛 Bug 修复 | Bug fix
- [x] ✨ 新功能 | New feature
- [ ] 📝 文档更新 | Documentation update
- [ ] 🎨 代码优化 | Code refactoring
- [ ] ⚡️ 性能优化 | Performance improvement
- [ ] 🔧 配置变更 | Configuration change
- [ ] 🧪 测试相关 | Test related
- [ ] 🔨 构建相关 | Build related
- [ ] 🌐 国际化 | Internationalization

## 📋 改动内容 | Changes Made

<!-- 请详细列出你的改动 | Please list your changes in detail -->

- 

## 🧪 测试 | Testing

<!-- 请描述你如何测试这些改动 | Please describe how you tested these changes -->

- [x] 本地编译通过 | Local build passed
- [x] 功能测试通过 | Functional tests passed
- [ ] 在以下环境测试 | Tested on:
  - [x] Windows
  - [ ] macOS
  - [ ] Linux

## 📸 截图 | Screenshots

<!-- 如果有 UI 相关改动，请提供截图 | If there are UI changes, please provide screenshots -->

http界面

<img width="1875" height="1117" alt="image" src="https://github.com/user-attachments/assets/cf7afabe-09e6-4094-9bda-59c3107a24e8" />

sse界面

<img width="1875" height="1117" alt="image" src="https://github.com/user-attachments/assets/8f967f68-0fcf-47ab-836b-de3300d23025" />


## ✅ 检查清单 | Checklist

<!-- 提交前请确认以下事项 | Please confirm the following before submitting -->

- [x] 代码遵循项目编码规范 | Code follows the project's coding standards
- [x] 已添加必要的注释 | Added necessary comments
- [x] 文档已更新（如需要）| Documentation updated (if needed)
- [x] 没有引入新的警告 | No new warnings introduced
- [x] 改动不影响现有功能 | Changes do not affect existing functionality
- [x] 已在本地完整测试 | Fully tested locally

## 💡 其他说明 | Additional Notes

<!-- 其他需要说明的内容 | Any additional information -->

后续可能还会针对sse响应体的展示效果做调整。

---

感谢你的贡献！ | Thank you for your contribution! 🎉

