### PR TITLE
Fix garbled UnknownHostException messages

### DIFF
--- a/easy-postman-app/src/main/java/com/laker/postman/panel/collections/editor/request/HttpRequestExecutor.java
+++ b/easy-postman-app/src/main/java/com/laker/postman/panel/collections/editor/request/HttpRequestExecutor.java
@@ -141,7 +141,12 @@ final class HttpRequestExecutor {
                         }
                     }
                 } catch (Exception ex) {
-                    log.error("Error executing HTTP request: {} {} - {}", req.method, req.url, ex.getMessage(), ex);
+                    String logMessage = NetworkErrorMessageResolver.toLogMessage(ex);
+                    if (ex instanceof java.net.UnknownHostException) {
+                        log.error("Error executing HTTP request: {} {} - {}", req.method, req.url, logMessage);
+                    } else {
+                        log.error("Error executing HTTP request: {} {} - {}", req.method, req.url, logMessage, ex);
+                    }
                     if (isCancelled()) {
                         userCanceled = true;
                         resp = HttpExchangeTerminalResponseFactory.fromCancellation(req, requestStartMs, System.currentTimeMillis());

--- a/easy-postman-app/src/main/java/com/laker/postman/panel/collections/editor/request/SseRequestExecutor.java
+++ b/easy-postman-app/src/main/java/com/laker/postman/panel/collections/editor/request/SseRequestExecutor.java
@@ -128,7 +128,12 @@ final class SseRequestExecutor {
                     ));
                     responsePanel.setResponseTabButtonsEnable(true);
                 } catch (Exception ex) {
-                    log.error("Error executing SSE request: {} - {}", req.url, ex.getMessage(), ex);
+                    String logMessage = NetworkErrorMessageResolver.toLogMessage(ex);
+                    if (ex instanceof java.net.UnknownHostException) {
+                        log.error("Error executing SSE request: {} - {}", req.url, logMessage);
+                    } else {
+                        log.error("Error executing SSE request: {} - {}", req.url, logMessage, ex);
+                    }
                     String userFriendlyMessage = NetworkErrorMessageResolver.toUserFriendlyMessage(ex);
                     SwingUtilities.invokeLater(() -> {
                         if (executionState.isDisposed()) {

--- a/easy-postman-app/src/main/resources/messages_en.properties
+++ b/easy-postman-app/src/main/resources/messages_en.properties
@@ -2363,6 +2363,7 @@ settings.proxy.status.system.active=Current status: system proxy preview for {0}
 settings.proxy.status.direct=direct
 settings.proxy.status.unavailable=unavailable
 network.error.proxy.socks.malformed=Proxy handshake failed: the request is using a SOCKS proxy, but the server did not return a valid SOCKS response. This usually means the proxy type or port is wrong. Check whether the proxy type (HTTP/SOCKS) in Settings -> Network Proxy matches the actual proxy port, or disable the network proxy and try again.\nOriginal error: {0}
+network.error.unknown_host=Unable to resolve host: {0}. Check your baseUrl, proxy configuration, or local DNS settings.
 # WebDAV Sync
 settings.webdav_sync.title=WebDAV Sync
 settings.webdav_sync.description=Package workspace data, global variables, shortcuts, and core preferences into a snapshot for manual upload or restore across personal devices. History, plugins, certificates, Git repository metadata (.git), and local runtime state are not synced. Git workspaces restored from WebDAV become local workspaces.

--- a/easy-postman-app/src/main/resources/messages_zh.properties
+++ b/easy-postman-app/src/main/resources/messages_zh.properties
@@ -2377,6 +2377,7 @@ settings.proxy.status.system.active=当前状态：系统代理预览（{0}）\n
 settings.proxy.status.direct=直连
 settings.proxy.status.unavailable=无法解析
 network.error.proxy.socks.malformed=代理握手失败：当前按 SOCKS 代理连接，但代理服务器返回的不是合法的 SOCKS 响应。通常是代理类型或端口配置错误。请检查“设置 -> 网络代理”中的代理类型（HTTP/SOCKS）是否与实际端口一致，或先关闭网络代理后重试。\n原始错误：{0}
+network.error.unknown_host=无法解析主机名：{0}。请检查 baseUrl、代理配置或本机 DNS 设置。
 # ============ WebDAV 同步 ============
 settings.webdav_sync.title=WebDAV 同步
 settings.webdav_sync.description=将工作区数据、全局变量、快捷键和核心偏好打包为快照，通过 WebDAV 在个人设备之间手动上传或恢复。历史记录、插件、证书、Git 仓库元数据（.git）和本机运行状态不会同步；Git 工作区通过 WebDAV 恢复后会作为本地工作区使用。

--- a/easy-postman-app/src/test/java/com/laker/postman/http/runtime/error/NetworkErrorMessageResolverTest.java
+++ b/easy-postman-app/src/test/java/com/laker/postman/http/runtime/error/NetworkErrorMessageResolverTest.java
@@ -2,7 +2,10 @@ package com.laker.postman.http.runtime.error;
 
 import org.testng.annotations.Test;
 
+import java.net.UnknownHostException;
+
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 public class NetworkErrorMessageResolverTest {
@@ -21,5 +24,16 @@ public class NetworkErrorMessageResolverTest {
         String rawMessage = "Connection reset by peer";
 
         assertEquals(NetworkErrorMessageResolver.toUserFriendlyMessage(rawMessage), rawMessage);
+    }
+
+    @Test
+    public void shouldReplaceGarbledUnknownHostMessageWithLocalizedHostHint() {
+        UnknownHostException ex = new UnknownHostException("涓嶇煡閬撹繖鏍风殑涓绘満銆� (oktadomainq)");
+
+        String message = NetworkErrorMessageResolver.toUserFriendlyMessage(ex);
+
+        assertTrue(message.contains("oktadomainq"));
+        assertTrue(message.contains("baseUrl"));
+        assertFalse(message.contains("涓嶇煡"));
     }
 }

--- a/easy-postman-foundation/src/main/java/com/laker/postman/util/MessageKeys.java
+++ b/easy-postman-foundation/src/main/java/com/laker/postman/util/MessageKeys.java
@@ -2341,6 +2341,7 @@ public final class MessageKeys {
     public static final String SETTINGS_PROXY_STATUS_DIRECT = "settings.proxy.status.direct";
     public static final String SETTINGS_PROXY_STATUS_UNAVAILABLE = "settings.proxy.status.unavailable";
     public static final String NETWORK_ERROR_PROXY_SOCKS_MALFORMED = "network.error.proxy.socks.malformed";
+    public static final String NETWORK_ERROR_UNKNOWN_HOST = "network.error.unknown_host";
 
     // WebDAV 同步设置
     public static final String SETTINGS_WEBDAV_SYNC_TITLE = "settings.webdav_sync.title";

--- a/easy-postman-http-runtime/src/main/java/com/laker/postman/http/runtime/error/NetworkErrorMessageResolver.java
+++ b/easy-postman-http-runtime/src/main/java/com/laker/postman/http/runtime/error/NetworkErrorMessageResolver.java
@@ -3,8 +3,14 @@ package com.laker.postman.http.runtime.error;
 import com.laker.postman.util.I18nUtil;
 import com.laker.postman.util.MessageKeys;
 
+import java.net.UnknownHostException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public final class NetworkErrorMessageResolver {
     private static final String SOCKS_MALFORMED_REPLY = "Malformed reply from SOCKS server";
+    private static final Pattern UNKNOWN_HOST_PAREN_PATTERN = Pattern.compile("\\(([^()]+)\\)\\s*$");
+    private static final Pattern UNKNOWN_HOST_PREFIX_PATTERN = Pattern.compile("^([A-Za-z0-9._-]+)(?::\\s.*)?$");
 
     private NetworkErrorMessageResolver() {
     }
@@ -12,6 +18,9 @@ public final class NetworkErrorMessageResolver {
     public static String toUserFriendlyMessage(Throwable throwable) {
         if (throwable == null) {
             return "";
+        }
+        if (throwable instanceof UnknownHostException) {
+            return resolveUnknownHostMessage(throwable.getMessage());
         }
         return toUserFriendlyMessage(throwable.getMessage());
     }
@@ -22,5 +31,61 @@ public final class NetworkErrorMessageResolver {
             return I18nUtil.getMessage(MessageKeys.NETWORK_ERROR_PROXY_SOCKS_MALFORMED, normalized);
         }
         return normalized;
+    }
+
+    public static String toLogMessage(Throwable throwable) {
+        if (throwable == null) {
+            return "";
+        }
+        if (throwable instanceof UnknownHostException) {
+            return resolveUnknownHostMessage(throwable.getMessage());
+        }
+        return toUserFriendlyMessage(throwable);
+    }
+
+    private static String resolveUnknownHostMessage(String rawMessage) {
+        String host = extractUnknownHost(rawMessage);
+        if (!host.isBlank()) {
+            return I18nUtil.getMessage(MessageKeys.NETWORK_ERROR_UNKNOWN_HOST, host);
+        }
+        return I18nUtil.getMessage(MessageKeys.ERROR_SERVER_UNREACHABLE);
+    }
+
+    private static String extractUnknownHost(String rawMessage) {
+        String normalized = rawMessage == null ? "" : rawMessage.trim();
+        if (normalized.isBlank()) {
+            return "";
+        }
+
+        Matcher parenMatcher = UNKNOWN_HOST_PAREN_PATTERN.matcher(normalized);
+        if (parenMatcher.find()) {
+            String host = parenMatcher.group(1).trim();
+            if (isLikelyHost(host)) {
+                return host;
+            }
+        }
+
+        Matcher prefixMatcher = UNKNOWN_HOST_PREFIX_PATTERN.matcher(normalized);
+        if (prefixMatcher.matches()) {
+            String host = prefixMatcher.group(1).trim();
+            if (isLikelyHost(host)) {
+                return host;
+            }
+        }
+
+        return "";
+    }
+
+    private static boolean isLikelyHost(String value) {
+        if (value.isBlank()) {
+            return false;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if (!(Character.isLetterOrDigit(ch) || ch == '.' || ch == '-' || ch == '_')) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/easy-postman-http-runtime/src/main/java/com/laker/postman/http/runtime/transport/HttpExchangeTerminalResponseFactory.java
+++ b/easy-postman-http-runtime/src/main/java/com/laker/postman/http/runtime/transport/HttpExchangeTerminalResponseFactory.java
@@ -110,8 +110,9 @@ public class HttpExchangeTerminalResponseFactory {
             sb.append("-");
         } else {
             sb.append(throwable.getClass().getName());
-            if (throwable.getMessage() != null && !throwable.getMessage().isBlank()) {
-                sb.append(": ").append(throwable.getMessage());
+            String diagnosticMessage = NetworkErrorMessageResolver.toLogMessage(throwable);
+            if (diagnosticMessage != null && !diagnosticMessage.isBlank()) {
+                sb.append(": ").append(diagnosticMessage);
             }
         }
         return sb.toString();


### PR DESCRIPTION
Ensure UnknownHostException errors use localized host-resolution messages instead of platform-dependent garbled text in logs and UI.

## 📝 PR 描述 | Description

优化请求URL中的主机不可解析的时候的错误信息提示，原来的提示是乱码提示

## 🔗 相关 Issue | Related Issue

https://github.com/lakernote/EasyPostman/issues/140

Fixes #(issue number)

## 🎯 改动类型 | Type of Change

<!-- 请勾选适用的选项 | Please check the applicable options -->

- [x] 🐛 Bug 修复 | Bug fix
- [ ] ✨ 新功能 | New feature
- [ ] 📝 文档更新 | Documentation update
- [ ] 🎨 代码优化 | Code refactoring
- [ ] ⚡️ 性能优化 | Performance improvement
- [ ] 🔧 配置变更 | Configuration change
- [ ] 🧪 测试相关 | Test related
- [ ] 🔨 构建相关 | Build related
- [ ] 🌐 国际化 | Internationalization

## 📋 改动内容 | Changes Made

easy-postman-http-runtime\src\main\java\com\laker\postman\http\runtime\error\NetworkErrorMessageResolver.java : 
- 新增  UnknownHostException  专门处理
- 从异常消息里提取主机名，例如  hjhjhjh
- 返回项目自己的国际化提示，而不是系统原始乱码
- 新增  toLogMessage(...) ，给日志链路也用

easy-postman-app\src\main\java\com\laker\postman\panel\collections\editor\request\HttpRequestExecutor.java 
easy-postman-app\src\main\java\com\laker\postman\panel\collections\editor\request\SseRequestExecutor.java 
:
- 不再直接记录  ex.getMessage() 
- 对  UnknownHostException  不再附带那段乱码栈消息
- easy-postman-http-runtime\src\main\java\com\laker\postman\http\runtime\transport\HttpExchangeTerminalResponseFactory.java 
- 网络失败日志摘要也不再透传乱码原文
- 新增国际化 key：
- network.error.unknown_host 

修改之后请求URL中包含非法hostname无法解析的时候会报错：

- 中文： 无法解析主机名：{非法的主机名}。请检查 baseUrl、代理配置或本机 DNS 设置。 
- 英文: Unable to resolve host: {非法的主机名}. Check your baseUrl, proxy configuration, or local DNS settings.

## 🧪 测试 | Testing

非法主机名不再显示乱码  最新报错提示参考截图

控制台日志：
17:18:11.969 [SwingWorker-pool-2-thread-1] ERROR c.l.p.p.c.e.r.HttpRequestExecutor :146 Error executing HTTP request: POST https://oktaDomainq/oauth2/auhgdsds5565dssdj/v1/token - 无法解析主机名：oktadomainq。请检查 baseUrl、代理配置或本机 DNS 设置。

- [x] 本地编译通过 | Local build passed
- [x] 功能测试通过 | Functional tests passed
- [ ] 在以下环境测试 | Tested on:
  - [x] Windows
  - [ ] macOS
  - [ ] Linux

## 📸 截图 | Screenshots

<img width="429" height="133" alt="image" src="https://github.com/user-attachments/assets/19b50a73-8c1d-46ea-958b-a684a169ce22" />

## ✅ 检查清单 | Checklist

<!-- 提交前请确认以下事项 | Please confirm the following before submitting -->

- [ ] 代码遵循项目编码规范 | Code follows the project's coding standards
- [ ] 已添加必要的注释 | Added necessary comments
- [ ] 文档已更新（如需要）| Documentation updated (if needed)
- [ ] 没有引入新的警告 | No new warnings introduced
- [ ] 改动不影响现有功能 | Changes do not affect existing functionality
- [x] 已在本地完整测试 | Fully tested locally

## 💡 其他说明 | Additional Notes

<!-- 其他需要说明的内容 | Any additional information -->

---

感谢你的贡献！ | Thank you for your contribution! 🎉

